### PR TITLE
Ignore macOS files in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,30 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
+### macOS template
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk


### PR DESCRIPTION
### What?
- [x] Add `"macOS tempate"` to `.gitignore`.

### Why?
So that macOS users do not commit files, such as `.DS_Store`.