### PR TITLE
Added file extension check

### DIFF
--- a/locales/de/LC_MESSAGES/bot.po
+++ b/locales/de/LC_MESSAGES/bot.po
@@ -72,3 +72,7 @@ msgstr "Fehler"
 #: main.py:176
 msgid "bot.deleted_successfully"
 msgstr "Anzeige erfolgreich gelöscht ✨"
+
+#: main.py:186
+msgid "bot.invalid_photo_extension"
+msgstr "Invalid photo extension"

--- a/locales/en/LC_MESSAGES/bot.po
+++ b/locales/en/LC_MESSAGES/bot.po
@@ -72,3 +72,7 @@ msgstr "Error"
 #: main.py:176
 msgid "bot.deleted_successfully"
 msgstr "Listing successfully deleted ✨"
+
+#: main.py:186
+msgid "bot.invalid_photo_extension"
+msgstr "Invalid photo extension"

--- a/locales/hi/LC_MESSAGES/bot.po
+++ b/locales/hi/LC_MESSAGES/bot.po
@@ -72,3 +72,7 @@ msgstr "त्रुटि"
 #: main.py:176
 msgid "bot.deleted_successfully"
 msgstr "विज्ञापन सफलतापूर्वक हटाया गया ✨"
+
+#: main.py:186
+msgid "bot.invalid_photo_extension"
+msgstr "Invalid photo extension"

--- a/locales/id/LC_MESSAGES/bot.po
+++ b/locales/id/LC_MESSAGES/bot.po
@@ -72,3 +72,7 @@ msgstr "Kesalahan"
 #: main.py:176
 msgid "bot.deleted_successfully"
 msgstr "Iklan berhasil dihapus ✨"
+
+#: main.py:186
+msgid "bot.invalid_photo_extension"
+msgstr "Invalid photo extension"

--- a/locales/uk/LC_MESSAGES/bot.po
+++ b/locales/uk/LC_MESSAGES/bot.po
@@ -72,3 +72,7 @@ msgstr "Помилка"
 #: main.py:176
 msgid "bot.deleted_successfully"
 msgstr "Оголошення успішно видалено ✨"
+
+#: main.py:186
+msgid "bot.invalid_photo_extension"
+msgstr "Invalid photo extension"

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from aiogram.types.callback_query import CallbackQuery
 from dotenv import load_dotenv
 
 from po_compile import compile_all_languages
+from utils.data_validation import validate_photo_as_document
 
 load_dotenv()
 compile_all_languages()
@@ -178,6 +179,15 @@ async def publish_post(message: aiogram.types.Message, state: FSMContext):
 async def enter_photo_as_document(message: aiogram.types.Message, state: FSMContext):
     # get photo as document
     document = message.document
+
+    # validate photo
+    if validate_photo_as_document(document) is False:
+        await message.reply(
+            i18n.gettext("bot.invalid_photo_extension", locale=BOT_LANGUAGE),
+            reply_markup=sell_keyboard,
+        )
+        return
+
     await document.download(destination_file="item_photo.jpg")
 
     # publishing a post

--- a/utils/data_validation.py
+++ b/utils/data_validation.py
@@ -1,0 +1,12 @@
+import mimetypes
+from aiogram.types import Document
+
+
+def validate_photo_as_document(file: Document) -> bool:
+    """Validation of a photo uploaded as a document"""
+
+    # checking the file extension
+    photo_type = mimetypes.guess_type(file.file_name)
+    if photo_type[0] is None:
+        return False
+    return photo_type[0].startswith("image")


### PR DESCRIPTION
Verification occurs only in `enter_photo_as_document`. If the file is not an image, the user receives a message about it. I hope this is the proper behavior.
I added a message in all localization files, but did not translate it.